### PR TITLE
Moved roll result extraction to UDF. Updated extraction RegEx.

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "Dice Widget",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "website": "daedeross.github.io",
     "gitUrl": "github.com/Daedeross/https://github.com/Daedeross/MapToolDiceWidget",
     "authors": [ "Bryan C. Jones" ],

--- a/library/mtscript/extractResult.mts
+++ b/library/mtscript/extractResult.mts
@@ -1,0 +1,9 @@
+[h: assert(argCount() == 1, "'extractResult' Invalid Arg Count")]
+[h: id = strfind(arg(0), "(?:\\x1F|=)\\s*(-?\\d+)\\x1E")]
+[h, if(getFindCount(id) == 0), code: {
+    [h: macro.return = 0]
+};{
+    [h: result = number(getGroup(id, 1, 1))]
+    [h: assert(isNumber(result), "invalid dice expression")]
+    [h: macro.return = result]
+}]

--- a/library/mtscript/public/executeRoll.mts
+++ b/library/mtscript/public/executeRoll.mts
@@ -24,9 +24,7 @@
 [h: best = if(takeHighest, -2147483647, 2147483647)]
 [h, for(i, 0, times, 1, ""), code: {
     [h: resultText = evalMacro(strformat("[%{expression}]"))]
-    [h: id = strfind(resultText, "\\x1F(-?\\d+)\\x1E")]
-    [h: result = number(getGroup(id, 1, 1))]
-    [h: assert(isNumber(result), "invalid dice expression")]
+    [h: result = extractResult(resultText)]
     [h: results = json.append(results, result)]
     [h: resultTexts = json.append(resultTexts, resultText)]
     [h, if((takeHighest && result > best) || (!takeHighest && result < best)), code : {

--- a/library/mtscript/public/onInit.mts
+++ b/library/mtscript/public/onInit.mts
@@ -1,4 +1,5 @@
 [h: defineFunction("data.exists", "dataExists@this", true)]
+[h: defineFunction("extractResult", "extractResult@this", true)]
 
 [h: exists = data.exists("daedeross.roll", "data/global-settings.json")]
 [h, if(!exists), code: {

--- a/overlay/roll/package-lock.json
+++ b/overlay/roll/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mt-roll-widget",
-  "version": "0.1.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mt-roll-widget",
-      "version": "0.1.0",
+      "version": "0.4.1",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
         "fast-json-patch": "^3.1.1",

--- a/overlay/roll/package.json
+++ b/overlay/roll/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mt-roll-widget",
-  "version": "0.1.0",
+  "version": "0.4.1",
   "private": true,
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.5",


### PR DESCRIPTION
- Moved Roll result extraction to UDF.
- Updated extraction RegEx to handle exploding (i.e. [e:] roll option) results.
- Bumped library version number.
- Bumped WebApp version to coincide with library version.
- Closes #2  